### PR TITLE
Drupal9 readiness

### DIFF
--- a/elasticsearch_helper_content.info.yml
+++ b/elasticsearch_helper_content.info.yml
@@ -1,7 +1,7 @@
 name: Elasticsearch Helper Content
 type: module
 description: Versatile generic elasticsearch indexing for typical content entities.
-core: 8.x
+core_version_requirement: ^8.8.0 || ^9
 package: ElasticSearch Helper
 dependencies:
-  - elasticsearch_helper
+  - drupal:elasticsearch_helper

--- a/elasticsearch_helper_content.services.yml
+++ b/elasticsearch_helper_content.services.yml
@@ -3,7 +3,7 @@ services:
     class: Drupal\elasticsearch_helper_content\Plugin\Normalizer\ElasticsearchContentNormalizer
     tags:
       - { name: normalizer, priority: 50 }
-    arguments: ['@entity_type.manager', '@entity_type.repository', '@entity_field.manager', '@config.factory', '@renderer', '@theme.manager', '@theme.initialization', '@language_manager', '@entity_type.bundle.info']
+    arguments: ['@entity_type.manager', '@entity_type.repository', '@entity_field.manager', '@config.factory', '@renderer', '@theme.manager', '@theme.initialization', '@language_manager', '@entity_type.bundle.info', '@entity_display.repository']
 
   elasticsearch_helper_content.entity_renderer:
     class: Drupal\elasticsearch_helper_content\EntityRenderer

--- a/src/ElasticsearchNormalizerInterface.php
+++ b/src/ElasticsearchNormalizerInterface.php
@@ -2,14 +2,14 @@
 
 namespace Drupal\elasticsearch_helper_content;
 
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\ConfigurableInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
 
 /**
  * Defines interface for Elasticsearch normalizer plugins.
  */
-interface ElasticsearchNormalizerInterface extends PluginInspectionInterface, ConfigurablePluginInterface, PluginFormInterface {
+interface ElasticsearchNormalizerInterface extends PluginInspectionInterface, ConfigurableInterface, PluginFormInterface {
 
   /**
    * Returns property definitions.

--- a/src/Plugin/Normalizer/ElasticsearchContentNormalizer.php
+++ b/src/Plugin/Normalizer/ElasticsearchContentNormalizer.php
@@ -2,14 +2,16 @@
 
 namespace Drupal\elasticsearch_helper_content\Plugin\Normalizer;
 
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityTypeRepositoryInterface;
 use Drupal\Core\Language\LanguageManager;
 use Drupal\Core\TypedData\TranslatableInterface;
 use Drupal\serialization\Normalizer\ContentEntityNormalizer;
 use Drupal\Core\Theme\ThemeManager;
 use Drupal\Core\Theme\ThemeInitialization;
-use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\core\Entity\EntityManagerInterface;
 use Drupal\core\Entity\ContentEntityBase;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\Config\ConfigFactory;
@@ -35,9 +37,9 @@ class ElasticsearchContentNormalizer extends ContentEntityNormalizer {
   protected $format = ['elasticsearch_helper'];
 
   /**
-   * The entity_type.manager service.
+   * The entity type manager service.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -84,19 +86,28 @@ class ElasticsearchContentNormalizer extends ContentEntityNormalizer {
   protected $entityTypeBundleInfo;
 
   /**
+   * The entity display repository.
+   *
+   * @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface
+   */
+  protected $entityDisplayRepository;
+
+  /**
    * Constructs a new FilefieldDownloader object.
    */
   public function __construct(
-    EntityManagerInterface $entity_manager,
-    EntityTypeManager $entity_type_manager,
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityTypeRepositoryInterface $entity_type_repository,
+    EntityFieldManagerInterface $entity_field_manager,
     ConfigFactory $config_factory,
     Renderer $renderer,
     ThemeManager $theme_manager,
     ThemeInitialization $theme_initialization,
     LanguageManager $language_manager,
-    EntityTypeBundleInfo $entity_type_bundle_info
+    EntityTypeBundleInfo $entity_type_bundle_info,
+    EntityDisplayRepositoryInterface $entity_display_repository
   ) {
-    parent::__construct($entity_manager);
+    parent::__construct($entity_type_manager, $entity_type_repository, $entity_field_manager);
     $this->entityTypeManager = $entity_type_manager;
     $this->configFactory = $config_factory;
     $this->renderer = $renderer;
@@ -104,6 +115,7 @@ class ElasticsearchContentNormalizer extends ContentEntityNormalizer {
     $this->themeInitialization = $theme_initialization;
     $this->languageManager = $language_manager;
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
+    $this->entityDisplayRepository = $entity_display_repository;
   }
 
   /**
@@ -264,7 +276,7 @@ class ElasticsearchContentNormalizer extends ContentEntityNormalizer {
     // @Todo Check what happens if $view_mode has no explicit settings.
     //       (I.e. when "default" should be used => is this working automatically?)
     /** @var \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display */
-    $display = entity_get_display($entity->getEntityTypeId(), $entity->bundle(), $view_mode);
+    $display = $this->entityDisplayRepository->getViewDisplay($entity->getEntityTypeId(), $entity->bundle(), $view_mode);
     $display_components = $display->getComponents();
     uasort($display_components, function ($a, $b) {
       return $a['weight'] - $b['weight'];

--- a/src/Plugin/views/field/Numeric.php
+++ b/src/Plugin/views/field/Numeric.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\elasticsearch_helper_content\Plugin\views\field;
 
-use Drupal\elasticsearch_helper_views\Plugin\views\field\SourceValueTrait;
 use Drupal\views\Plugin\views\field\NumericField;
 
 /**
@@ -13,7 +12,5 @@ use Drupal\views\Plugin\views\field\NumericField;
  * @ViewsField("elasticsearch_content_numeric")
  */
 class Numeric extends NumericField {
-
-  use SourceValueTrait;
 
 }

--- a/src/Plugin/views/field/StringField.php
+++ b/src/Plugin/views/field/StringField.php
@@ -2,8 +2,7 @@
 
 namespace Drupal\elasticsearch_helper_content\Plugin\views\field;
 
-use Drupal\elasticsearch_helper_views\Plugin\views\field\SourceValueTrait;
-use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\elasticsearch_helper_views\Plugin\views\field\Source;
 
 /**
  * Renders a field as a string.
@@ -12,8 +11,6 @@ use Drupal\views\Plugin\views\field\FieldPluginBase;
  *
  * @ViewsField("elasticsearch_content_string")
  */
-class StringField extends FieldPluginBase {
-
-  use SourceValueTrait;
+class StringField extends Source {
 
 }


### PR DESCRIPTION
This PR adds Drupal 9 readiness for elasticsearch_helper_content module.

Updates:
- Updated elasticsearch_helper_content.normalizer.elasticsearch_content_normalizer service arguments and updated ElasticsearchContentNormalizer constructor
   - parent construct call expects that entity type repository and entity field manager are passed to the constructor. (See https://www.drupal.org/node/2549139)
   - injected the entity display repository
- Replaced entity_get_display() with EntityDisplayRepositoryInterface (See https://www.drupal.org/node/2835616)
- Replaced ConfigurablePluginInterface with ConfigurableInterface (See https://www.drupal.org/node/2946161)
- Updated views fields for numeric and string fields (were using mysterious SourceValueTrait)

Checked with Upgrade status.

Note: Didn't touch es 7.x related issues - updated once middle layer service available.